### PR TITLE
integration test and READMEs

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -17,13 +17,14 @@ action "Test" {
 
 action "Acceptance Test Auth" {
   uses = "./auth"
-	secrets = ["GCLOUD_AUTH"]
+  secrets = ["GCLOUD_AUTH"]
 }
 
 action "Acceptance Test CLI" {
   needs = ["Acceptance Test Auth"]
   uses = "./cli"
   args = "auth list --filter no-such-account"
+  secrets = ["GCLOUD_AUTH"]
 }
 
 action "Build" {

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -15,8 +15,19 @@ action "Test" {
   args = "test"
 }
 
+action "Acceptance Test Auth" {
+  uses = "./auth"
+	secrets = ["GCLOUD_AUTH"]
+}
+
+action "Acceptance Test CLI" {
+  needs = ["Acceptance Test Auth"]
+  uses = "./cli"
+  args = "auth list --filter no-such-account"
+}
+
 action "Build" {
-  needs = ["Lint", "Test"]
+  needs = ["Lint", "Test", "Acceptance Test CLI"]
   uses = "actions/action-builder/docker@master"
   runs = "make"
   args = "build"

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,10 +1,12 @@
 # GitHub Action for Google Cloud Auth
 
-The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/)  and wraps the [gcloud SDK](https://cloud.google.com/sdk/) for authorizing a service account.
+The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/) and wraps the [gcloud SDK](https://cloud.google.com/sdk/) for authorizing a service account. This is a thin wrapper around the `gcloud auth` command, facilitating providing credentials securely using [Secrets](https://developer.github.com/actions/creating-workflows/storing-secrets/).
 
 ## Usage
-An example workflow to authenticate with Google Cloud Platform and run the `gcloud` command:
 
+### Example Workflow file
+
+An example workflow to authenticate with Google Cloud Platform:
 
 ```
 workflow "Run gcloud Login" {
@@ -13,20 +15,18 @@ workflow "Run gcloud Login" {
 }
 
 action "Setup Google Cloud" {
-  uses = "docker://github/gcloud-auth"
+  uses = "actions/gcloud/auth@master"
   secrets = ["GCLOUD_AUTH"]
-}
-
-action "Load credentials" {
-  needs = ["Setup Google Cloud"]
-  uses = "docker://github/gcloud"
-  args = "container clusters get-credentials example-project --zone us-central1-a --project data-services-engineering"
 }
 ```
 
+Subsequent actions in the workflow will then be able to use `gcloud` as that user ([see `cli` for examples](/cli)).
+
 ### Secrets
 
-* `GCLOUD_AUTH` **Required** Base64 encoded service account key exported as JSON [more info](https://cloud.google.com/sdk/docs/authorizing)
+* `GCLOUD_AUTH` **Required** Base64 encoded service account key exported as JSON
+   - For information about service accout keys please see the [Google Cloud docs](https://cloud.google.com/sdk/docs/authorizing)
+   - For information about using Credentials in Actions please see the [Actions docs](https://developer.github.com/actions/creating-workflows/storing-secrets/).
 
 Example on encoding from a terminal : `base64 ~/<account_id>.json`
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -26,7 +26,7 @@ Subsequent actions in the workflow will then be able to use `gcloud` as that use
 
 * `GCLOUD_AUTH` **Required** Base64 encoded service account key exported as JSON
    - For information about service accout keys please see the [Google Cloud docs](https://cloud.google.com/sdk/docs/authorizing)
-   - For information about using Credentials in Actions please see the [Actions docs](https://developer.github.com/actions/creating-workflows/storing-secrets/).
+   - For information about using Secrets in Actions please see the [Actions docs](https://developer.github.com/actions/creating-workflows/storing-secrets/).
 
 Example on encoding from a terminal : `base64 ~/<account_id>.json`
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -25,7 +25,7 @@ Subsequent actions in the workflow will then be able to use `gcloud` as that use
 ### Secrets
 
 * `GCLOUD_AUTH` **Required** Base64 encoded service account key exported as JSON
-   - For information about service accout keys please see the [Google Cloud docs](https://cloud.google.com/sdk/docs/authorizing)
+   - For information about service account keys please see the [Google Cloud docs](https://cloud.google.com/sdk/docs/authorizing)
    - For information about using Secrets in Actions please see the [Actions docs](https://developer.github.com/actions/creating-workflows/storing-secrets/).
 
 Example on encoding from a terminal : `base64 ~/<account_id>.json`

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # GitHub Action for Google Cloud
 
-The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/) and wraps the [gcloud SDK](https://cloud.google.com/sdk/) to enable common Google Cloud commands. This is a very thin wrapper around the `gcloud` utility.
+The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/) and wraps the [gcloud SDK](https://cloud.google.com/sdk/) to enable common Google Cloud commands. This is a thin wrapper around the `gcloud` utility.
 
 ## Usage
 An example workflow to list clusters on Google Cloud Platform:

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@ The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/) and wr
 An example workflow to list clusters on Google Cloud Platform:
 
 ```
-workflow "Run gcloud Login" {
+workflow "Run gcloud command" {
   on = "push"
   resolves = "Load credentials"
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,10 +1,9 @@
-# GitHub Action for Google Cloud Auth
+# GitHub Action for Google Cloud
 
-The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/)  and wraps the [gcloud SDK](https://cloud.google.com/sdk/) to enable common Google Cloud commands.
+The GitHub Actions for [Google Cloud Platform](https://cloud.google.com/) and wraps the [gcloud SDK](https://cloud.google.com/sdk/) to enable common Google Cloud commands. This is a very thin wrapper around the `gcloud` utility.
 
 ## Usage
-An example workflow to authenticate with Google Cloud Platform and run the `gcloud` command:
-
+An example workflow to list clusters on Google Cloud Platform:
 
 ```
 workflow "Run gcloud Login" {
@@ -12,17 +11,19 @@ workflow "Run gcloud Login" {
   resolves = "Load credentials"
 }
 
-action "Setup Google Cloud" {
-  uses = "docker://github/gcloud-auth"
+action "GCP Authenticate" {
+  uses = "actions/gcloud/auth@master"
   secrets = ["GCLOUD_AUTH"]
 }
 
-action "Load credentials" {
-  needs = ["Setup Google Cloud"]
-  uses = "docker://github/gcloud"
-  args = "container clusters get-credentials example-project --zone us-central1-a --project data-services-engineering"
+action "GCP List Clusters" {
+  needs = ["GCP Authenticate"]
+  uses = "actions/gcloud/cli@master"
+  args = "container clusters list"
 }
 ```
+
+For more information about the authentication step, ([see `cli`](/cli)).
 
 ## License
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -23,7 +23,7 @@ action "GCP List Clusters" {
 }
 ```
 
-For more information about the authentication step, ([see `cli`](/cli)).
+For more information about the authentication step, [see `auth`](/auth).
 
 ## License
 


### PR DESCRIPTION
This is an attempt to improve on the documentation, which was raised as an issue in https://github.com/actions/gcloud/issues/1.

I consciously tried to err away from documenting how to get Google Cloud service account keys or how to use the Action's Credentials feature and linked to them instead, so we don't end up with out of date docs. I'm not totally sure I've made the right choice there, it would be easier to get started if these docs single-handedly stepped through the process of using this action without having to dip in and out. I'm curious to hear what other people think.

As I was familiarising myself with how these actions worked I added a couple of basic acceptance tests to `.github/main.workflow`