### PR TITLE
Fix example workflow file

### DIFF
--- a/auth/README.md
+++ b/auth/README.md
@@ -11,7 +11,7 @@ An example workflow to authenticate with Google Cloud Platform:
 ```
 workflow "Run gcloud Login" {
   on = "push"
-  resolves = "Load credentials"
+  resolves = "Setup Google Cloud"
 }
 
 action "Setup Google Cloud" {


### PR DESCRIPTION
This way the example workflow file works out-of-the-box. Previously it throws an error because the "Load Credentials" action does not exist. Makes it (slightly) easier to get started.