### PR TITLE
bump gcloud version

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud-slim@sha256:7e910b97dd13d8e32acb3e53c5f4d2164c5ea8e93de1ea51e610a1112fa6308e
+FROM gcr.io/cloud-builders/gcloud-slim@sha256:d4ca671e5764c0f8f494a2a7540ced1753fbbe62af249e74c2fc0bbac6fa94fc
 
 LABEL name="gcloud-auth"
 LABEL version="1.0.1"

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-builders/gcloud-slim@sha256:7e910b97dd13d8e32acb3e53c5f4d2164c5ea8e93de1ea51e610a1112fa6308e
+FROM gcr.io/cloud-builders/gcloud-slim@sha256:d4ca671e5764c0f8f494a2a7540ced1753fbbe62af249e74c2fc0bbac6fa94fc
 
 LABEL "name"="gcloud"
 LABEL "version"="1.0.1"


### PR DESCRIPTION
What's in the box?
```
$ for v in 9ce2bb0f7459621450e1730c35c9620f23824e1c6d7a810c8eb1b80712d9af5a 7e910b97dd13d8e32acb3e53c5f4d2164c5ea8e93de1ea51e610a1112fa6308e; do
  echo $v;
  i=gcr.io/cloud-builders/gcloud-slim@sha256:$v;
  (docker inspect $i | jq -r '.[0].Created');
  (docker run --rm $i version);
  echo; echo;
done

9ce2bb0f7459621450e1730c35c9620f23824e1c6d7a810c8eb1b80712d9af5a
2018-10-05T08:28:12.208747232Z
Google Cloud SDK 219.0.1
bq 2.0.34
core 2018.09.28
gsutil 4.34

7e910b97dd13d8e32acb3e53c5f4d2164c5ea8e93de1ea51e610a1112fa6308e
2019-02-14T13:50:22.929180985Z
Google Cloud SDK 234.0.0
bq 2.0.41
core 2019.02.08
gsutil 4.36
```